### PR TITLE
explicitly define mime-type for egg files

### DIFF
--- a/pyshop/helpers/download.py
+++ b/pyshop/helpers/download.py
@@ -2,6 +2,7 @@ import os
 import os.path
 import mimetypes
 import logging
+
 import requests
 from zope.interface import implements
 from pyramid.interfaces import ITemplateRenderer


### PR DESCRIPTION
Fixes the issue where mimetypes can' guess mime for .egg file, and easy_install claims it's HTML file (See #12)
