### PR TITLE
correct path in manifest in for template inclusion

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,5 @@ include LICENSE
 include *.txt *.ini *.cfg *.rst
 recursive-exclude . *.pyc
 graft pyshop/static
-graft pythop/templates
+graft pyshop/templates
 graft pyshop/locale


### PR DESCRIPTION
The templates directory is omitted in the latest release from a small typo :smile: 
