### PR TITLE
Added fix for purge on postgres db

### DIFF
--- a/pyshop/bin/migration/migr_0_1_2_2.py
+++ b/pyshop/bin/migration/migr_0_1_2_2.py
@@ -1,0 +1,44 @@
+#-*- coding: utf-8 -*-
+"""
+migrate from 0.7.5 version.
+
+Alter the table release_file, to handle the format "bdist_wheel"
+
+see: http://wheel.readthedocs.org/en/latest/
+
+"""
+
+import os
+import sys
+
+
+from pyshop.models import DBSession
+
+def main(argv=sys.argv):
+
+    session = DBSession()
+
+    # Create temp table
+    session.execute("""
+    CREATE TABLE classifier__release_new (
+            classifier_id integer REFERENCES classifier ON DELETE CASCADE,
+            release_id integer REFERENCES release
+    );
+    """)
+
+    # Copy data to new table
+    session.execute("""
+    INSERT INTO classifier__release_new (
+            classifier_id, release_id)
+    SELECT  classifier_id, release_id
+    FROM classifier__release;
+    """)
+
+    # Swap the tables
+    session.execute("""
+    DROP TABLE classifier__release;
+    """)
+    session.execute("""
+    ALTER TABLE classifier__release_new RENAME TO classifier__release;
+    """)
+    session.commit()

--- a/pyshop/bin/migration/migr_1_2_3.py
+++ b/pyshop/bin/migration/migr_1_2_3.py
@@ -1,16 +1,13 @@
 #-*- coding: utf-8 -*-
 """
-migrate from 0.7.5 version.
+migrate from 1.2.2 version.
 
-Alter the table release_file, to handle the format "bdist_wheel"
-
-see: http://wheel.readthedocs.org/en/latest/
+Alter the table classifier__release with a cascade on delete.
 
 """
 
 import os
 import sys
-
 
 from pyshop.models import DBSession
 

--- a/pyshop/models.py
+++ b/pyshop/models.py
@@ -632,7 +632,7 @@ class Package(Base):
 
 classifier__release = Table('classifier__release', Base.metadata,
                             Column('classifier_id', Integer,
-                                   ForeignKey('classifier.id',ondelete='cascade')),
+                                   ForeignKey('classifier.id', ondelete='cascade')),
                             Column('release_id',
                                    Integer, ForeignKey('release.id'))
                             )

--- a/pyshop/models.py
+++ b/pyshop/models.py
@@ -631,8 +631,8 @@ class Package(Base):
 
 
 classifier__release = Table('classifier__release', Base.metadata,
-                            Column('classifier_id',
-                                   Integer, ForeignKey('classifier.id')),
+                            Column('classifier_id', Integer,
+                                   ForeignKey('classifier.id',ondelete='cascade')),
                             Column('release_id',
                                    Integer, ForeignKey('release.id'))
                             )


### PR DESCRIPTION
A fix for #52 . Deletes on the classifier__release will now cascade properly. Included a migration script, as I am running live servers.