### PR TITLE
Fix case insensitivity matching of packages names

### DIFF
--- a/pyshop/models.py
+++ b/pyshop/models.py
@@ -22,7 +22,7 @@ from pkg_resources import parse_version
 
 from sqlalchemy import (Table, Column, ForeignKey, Index,
                         Integer, Boolean, Unicode, UnicodeText,
-                        DateTime, Enum)
+                        DateTime, Enum, func)
 from sqlalchemy.orm import relationship, synonym, backref
 from sqlalchemy.sql.expression import func, or_, and_
 from sqlalchemy.ext.declarative import declared_attr
@@ -517,16 +517,13 @@ class Package(Base):
         :return: package instance
         :rtype: :class:`pyshop.models.Package`
         """
-        # XXX the field "name" should be created with a
-        # case insensitive collation.
-        pkg = cls.first(session, where=(cls.name.like(name),))
+        name = name.lower()
+        pkg = cls.first(session, where=(func.lower(cls.name).like(name),))
         if not pkg:
-            name = name.replace(u'-', u'_').upper()
+            # XXX _ is a LIKE operator, backslash it
+            name = name.replace(u'-', u'\\_')
             pkg = cls.first(session,
-                            where=(cls.name.like(name),))
-            # XXX _ is a like operator
-            if pkg and pkg.name.upper().replace(u'-', u'_') != name:
-                pkg = None
+                            where=(func.lower(cls.name).like(name),))
         return pkg
 
     @classmethod

--- a/pyshop/tests/case.py
+++ b/pyshop/tests/case.py
@@ -20,6 +20,10 @@ class ModelTestCase(TestCase):
     def setUp(self):
         transaction.begin()
         self.session = DBSession()
+        # With SQLite3 - used for tests - 'x' LIKE 'X' returns true which is
+        # not the case of, for instance, PostgreSQL. Disabling this behaviour
+        # makes tests more realistic.
+        self.session.execute('PRAGMA case_sensitive_like = ON')
 
     def tearDown(self):
         transaction.commit()

--- a/pyshop/tests/test_models.py
+++ b/pyshop/tests/test_models.py
@@ -89,6 +89,12 @@ class PackageTestCase(ModelTestCase):
         self.assertEqual(pkg.id, 1)
         self.assertEqual(pkg.name, u'mirrored_package1')
 
+        # Test case insensitivity
+        pkg = Package.by_name(self.session, u'MirRored_pAckaGe1')
+        self.assertIsInstance(pkg, Package)
+        self.assertEqual(pkg.id, 1)
+        self.assertEqual(pkg.name, u'mirrored_package1')
+
     def test_by_owner(self):
         from pyshop.models import Package
         pkges = Package.by_owner(self.session, u'johndo')


### PR DESCRIPTION
* fix tests to make SQLite3 using case sensitive comparisons for LIKE statements
* Update Package.by_name to lower the argument, and compare against the lowered value in database (so you don't need to have a case insensitive field, CITEXT for instance for PostgreSQL)