### PR TITLE
make xmlrpc requests to pypi over https

### DIFF
--- a/pyshop/helpers/pypi.py
+++ b/pyshop/helpers/pypi.py
@@ -40,7 +40,7 @@ class RequestsTransport(xmlrpc.Transport):
     user_agent = "PyShop"
 
     # override this if you'd like to https
-    use_https = False
+    use_https = True
 
     def request(self, host, handler, request_body, verbose):
         """


### PR DESCRIPTION
Upstream seems to be blocking XMLRPC requests that aren't using HTTPS.