### PR TITLE
Bug with dots in package names

### DIFF
--- a/pyshop/views/simple.py
+++ b/pyshop/views/simple.py
@@ -32,6 +32,10 @@ def _sanitize(input_str):
     return only_ascii
 
 
+def unify_package_name(package_name):
+    return package_name.lower().replace('-', '_').replace('.', '_')
+
+
 class List(View):
 
     def render(self):
@@ -268,11 +272,10 @@ class Show(View):
         if not search_count:
             return None
 
-        package_name = package_name.lower().replace('-', '_')
-        search_result = [p for p in search_result
-                         if p['name'].lower() == package_name
-                         or p['name'].lower().replace('-', '_') == package_name
-                         ]
+        search_result = [
+            p for p in search_result
+            if unify_package_name(p['name']) == unify_package_name(package_name)
+        ]
         log.debug('Found {sc}, matched {mc}'.format(sc=search_count,
                                                     mc=len(search_result)))
 

--- a/pyshop/views/xmlrpc.py
+++ b/pyshop/views/xmlrpc.py
@@ -214,6 +214,9 @@ class PyPI(XMLRPCView):
                 # hack https://mail.python.org/pipermail/catalog-sig/2012-October/004633.html
                 '_pypi_ordering':'',
                 } for r in release]
+        for r in rv:
+            if r.get('summary', None) is None:
+                r['summary'] = ''
         return rv
 
     def browse(self, classifiers):


### PR DESCRIPTION
Current search using XMLRPC in inconsistent with pip/simple protocol.
It's impossible to install (and mirror) package with `.` in name for example `zope.sqlalchemy` and `backports.functools_lru_cache`.

So I've implemented a small workaround using `json` api.
