### PR TITLE
allow authentication by an external webserver

### DIFF
--- a/pyshop.sample.ini
+++ b/pyshop.sample.ini
@@ -103,6 +103,18 @@ pyshop.ldap.last_name_attr =
 pyshop.ldap.email_attr = 
 
 
+# may pyshop use authentication info from a webserver?
+pyshop.remote_user.use_for_auth = False
+# server variable where login is
+pyshop.remote_user.login = REMOTE_USER
+# email domain for provided username
+# ex : example.com
+pyshop.remote_user.email_domain =
+# server variable where email is
+# ex : CUSTOM_EMAIL_HEADER
+pyshop.remote_user.email =
+
+
 [server:main]
 use = egg:waitress#main
 host = 0.0.0.0

--- a/pyshop/__init__.py
+++ b/pyshop/__init__.py
@@ -5,6 +5,7 @@ PyShop Web Application.
 import sys
 from pyramid.config import Configurator
 from pyramid.authorization import ACLAuthorizationPolicy as ACLPolicy
+from pyramid.settings import asbool
 
 from .security import groupfinder, RootFactory
 
@@ -29,8 +30,29 @@ def main(global_config, **settings):
     # after the template has been rendered
     create_engine(settings, scoped=True)
 
+    use_remote_user = asbool(settings.get('pyshop.remote_user.use_for_auth', 'False'))
+    remote_user_key = settings.get('pyshop.remote_user.login', 'REMOTE_USER')
+
+    if use_remote_user:
+        remote_user_email_domain = settings.get('pyshop.remote_user.email_domain')
+        remote_user_email_key = settings.get('pyshop.remote_user.email')
+        if remote_user_email_domain is None and remote_user_email_key is None:
+            raise RuntimeError("Pyshop is configured for server authentication, but email isn't "\
+                               "specified. Set either pyshop.remote_user.email_domain or "\
+                               "pyshop.remote_user.email in the config file")
+        if remote_user_email_key is not None:
+            email_factory = lambda login, request: request.environ.get(remote_user_email_key)
+        else:
+            email_factory = lambda login, reqeust: "%s@%s" % (login, remote_user_email_domain)
+    else:
+        email_factory = None
+
     authn_policy = RouteSwitchAuthPolicy(secret=settings['pyshop.cookie_key'],
-                                         callback=groupfinder)
+                                         callback=groupfinder,
+                                         use_remote_user=use_remote_user,
+                                         remote_user_key=remote_user_key,
+                                         remote_user_email_factory=email_factory)
+
     authz_policy = ACLPolicy()
     route_prefix = settings.get('pyshop.route_prefix')
 

--- a/pyshop/models.py
+++ b/pyshop/models.py
@@ -221,6 +221,28 @@ class User(Base):
             return user
 
     @classmethod
+    def by_remote_user_value(cls, session, login, email=None):
+        """User from a SSO service via REMOTE_USER or similar"""
+        user = cls.by_login(session, login)
+        if user is None:
+            log.debug('create user %s'%login)
+            user = User()
+            user.login = login
+            user.local = True
+            user.email = email
+            user.firstname = ''
+            user.lastname = ''
+            user.password = ''
+
+            for groupname in ["installer"]:
+                user.groups.append(Group.by_name(session, groupname))
+            if user.validate(session):
+                session.add(user)
+                log.debug('User "%s" added' % login)
+                transaction.commit()
+        return user
+
+    @classmethod
     def by_ldap_credentials(cls, session, login, password, settings):
         """if possible try to contact the LDAP for authentification if success
         and login don't exist localy create one and return it


### PR DESCRIPTION
This patch enables pyshop to use authentication provided by another webserver.
This functionality would typically be used while running pyshop in Apache
under mod_wsgi with some sort of single sign-on module providing auth.

Apache auth modules normally provide that information via the REMOTE_USER
server variable, so this patch looks there by default, but the specific
variable used can be controlled by setting pyshop.remote_user.login.

When using this mode pyshop will create users in the database if it hasn't
encountered them before. For this to work pyshop must be told how to get an
email address from the provided login. This patch permits appending a static
domain to the login (configured via pyshop.remote_user.email_domain), or via
reading another server variable that contains the full email address (set via
pyshop.remote_user.email).

Authentication via this method is only permitted for the web interface. The
interface used by pip and distutils is still limited to HTTP Basic auth. While
pip can be made to work with the use-case I had this patch in mind for (client
cert auth), distutils does not currently offer users support for anything
other than basic auth. This makes uploading packages impossible under such
a regimine. This may still be possible, but it would mostly come down to the
configuration of whatever is serving pyshop.