### PR TITLE
/pyshop/package/pkg_name error fix and display improvements

### DIFF
--- a/pyshop/templates/pyshop/package/show.html
+++ b/pyshop/templates/pyshop/package/show.html
@@ -22,32 +22,17 @@
 
   <p>
     {% trans %}Other Version:{% endtrans %}
-    {% set display = 0 %}
     {% for r in package.sorted_releases %}
-        {% if r.id == release.id %}
-            {% set idx = loop.index0 %}
-            {% set display = 1%}
-            {% if idx > 0 %}
-                <a class="btn btn-info btn-xs active" role="button"
-                    href="{{ route_url('show_package_version',
-                    package_name=package.name,
-                    release_version=package.sorted_releases[0].version)}}">
-                  <span class="glyphicon glyphicon-tag"></span>
-                  {{package.sorted_releases[0].version}}
-                </a>
-                ...
-            {% endif %}
-        {% endif %}
-        {% if display and loop.index <= idx + 10 %}
-            <a class="btn btn-info btn-xs active" 
-               role="button" 
+        {% if loop.index < 10 %}
+            <a class="btn btn-info btn-xs{% if r.id == release.id %} active{% endif %}"
+               role="button"
                href="{{ route_url('show_package_version', package_name=package.name, release_version=r.version)}}">
               <span class="glyphicon glyphicon-tag"></span>
                 {{r.version}}
             </a>
         {% endif %}
-        {% if loop.last and idx + 10 < loop.index %}
-            ...
+        {% if loop.last and loop.index >= 10 %}
+            <a class="btn btn-link btn-xs" role="button" href="{{ route_url('show_simple', package_name=package.name) }}">...</a>
         {% endif %}
     {% endfor %}
   </p>


### PR DESCRIPTION
Version: v1.2.3 fresh install today using pip in a virtualenv, running on Ubuntu 16.04 (xenial)

When more than one version of a package was uploaded (via `python setup.py sdist upload -v -r pyshop`), the `/pyshop/package/pkg_name` endpoint threw an internal server error:

```
  File "/root/pyshop/local/lib/python2.7/site-packages/pyshop/templates/pyshop/package/show.html", line 49, in block "main"
    {% if loop.last and idx + 10 < loop.index %}
UndefinedError: 'idx' is undefined
```

This is apparently due to scope of the `idx` variable being limited to the `{% if %}` block where it was defined.

The `display` variable was also suffering from a similar scope limitation, only being set as 1 within the if, and not updating the other `display` higher up, effectively rendering it ineffective.

This simplifies the version row a good deal.  End result looks like this:

![end result](https://dbwpescreen.s3.amazonaws.com/pyshop_fix_show_package_version.png)

Max 9 versions was chosen because 10 version numbers of this length put the 10th on the next line at max width.