### PR TITLE
Fix caching under pip 9

### DIFF
--- a/pyshop/templates/pyshop/simple/show.html
+++ b/pyshop/templates/pyshop/simple/show.html
@@ -8,7 +8,7 @@
             {%- endif -%}
         {%- else -%}
             <a href="{{ route_url('show_release_file', file_id=f.id, filename=f.filename)
-                     }}#{{ f.md5_digest }}">{{f.filename}}</a><br/>
+                     }}#md5={{ f.md5_digest }}">{{f.filename}}</a><br/>
         {% endif -%}
     {% endfor -%}
     {% if not r.files %}

--- a/pyshop/views/repository.py
+++ b/pyshop/views/repository.py
@@ -3,6 +3,7 @@
 PyShop Release File Download View.
 """
 from pyramid.settings import asbool
+import datetime
 
 from pyshop.models import DBSession, Release, ReleaseFile
 
@@ -39,6 +40,9 @@ def show_release_file(root, request):
     session.add(f.release.package)
     session.add(f.release)
     session.add(f)
+    request.response.etag = f.md5_digest
+    request.response.cache_control = 'max-age=31557600, public'
+    request.response.date = datetime.datetime.utcnow()
     return rv
 
 
@@ -70,4 +74,5 @@ def show_external_release_file(root, request):
     release.package.downloads += 1
     session.add(release.package)
     session.add(release)
+    request.response.date = datetime.datetime.utcnow()
     return rv


### PR DESCRIPTION
As far as I can tell, pip 9 requires all of the following to cache a downloaded file in the local HTTP cache:

   - link includes `#md5=`
   - ETag set to a value matching the md5
   - Date and Cache-Control headers set appropriately

I haven't tested this under 1.3.0 yet, but we're running this locally applied against 1.2.2 and it fixed HTTP response caching for us.