### PR TITLE
Feature: disallow version overwrites by policy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,5 @@ python:
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
     - "pip install -e ."
-    - "pip install git+https://github.com/jmcgeheeiv/pyfakefs"
 script:
     - "python ./setup.py nosetests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,6 @@ python:
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
     - "pip install -e ."
+    - "pip install git+https://github.com/jmcgeheeiv/pyfakefs"
 script:
     - "python ./setup.py nosetests"

--- a/pyshop.sample.ini
+++ b/pyshop.sample.ini
@@ -48,6 +48,9 @@ pyshop.upload.sanitize.regex = ^(?P<version>\d+\.\d+)(?P<extraversion>(?:\.\d+)*
 # uncomment to disable this behaviour
 pyshop.upload.rewrite_filename = 0
 
+# If set to 1, pyshop will not overwrite an existing package version on upload
+# pyshop.upload.never_overwrite = 1
+
 pyshop.mirror.cache.ttl = 24
 pyshop.mirror.sanitize = 0
 pyshop.mirror.sanitize.regex = ^[0-9]+(\.[0-9]+)*([a-f][0-9]*)?$

--- a/pyshop/tests/case.py
+++ b/pyshop/tests/case.py
@@ -13,6 +13,7 @@ from pyramid.httpexceptions import HTTPFound
 from pyramid.authorization import ACLAuthorizationPolicy
 
 from pyshop.models import DBSession
+from pyfakefs import fake_filesystem_unittest
 
 
 class ModelTestCase(TestCase):
@@ -37,7 +38,7 @@ class DummyRequest(testing.DummyRequest):
     matched_route = DummyRoute
 
 
-class UnauthenticatedViewTestCase(TestCase):
+class UnauthenticatedViewTestCase(fake_filesystem_unittest.TestCase):
 
     def setUp(self):
         from pyshop.config import includeme
@@ -50,6 +51,10 @@ class UnauthenticatedViewTestCase(TestCase):
         self.config.include(includeme)
         self.session = DBSession()
         transaction.begin()
+
+        # NB: testing.setUp() etc. depend on the real filesystem, so leave
+        # pyfakefs setup until last.
+        self.setUpPyfakefs()
 
     def tearDown(self):
         super(UnauthenticatedViewTestCase, self).tearDown()

--- a/pyshop/tests/views/test_simple.py
+++ b/pyshop/tests/views/test_simple.py
@@ -41,25 +41,30 @@ class SimpleTestCase(case.ViewTestCase):
             post={'content': DummyContent}))()
         self.assertIsInstance(view['release_file'], ReleaseFile)
 
-    def test_post_uploadreleasefile_existing_pkg_ok(self):
-        from pyramid.httpexceptions import HTTPForbidden
-
+    def test_post_uploadreleasefile_local_pkg(self):
+        from pyramid.httpexceptions import HTTPConflict
         from pyshop.views.simple import UploadReleaseFile
-        from pyshop.models import Package, Release, ReleaseFile
 
-        view = UploadReleaseFile(self.create_request({
-            'name': u'local_package1',
-            'content': DummyContent,
-            'version': u'0.2',
-            'filetype': u'sdist',
-            'md5_digest': u'x' * 40,
-            'home_page': u'http://local_package1'
-            }))()
-        self.assertEqual(set(view.keys()),
+        data = {'name': u'local_package1',
+                'content': DummyContent,
+                'version': u'0.2',
+                'filetype': u'sdist',
+                'md5_digest': u'x' * 40,
+                'home_page': u'http://local_package1'}
+
+        # Uploading an existing package is OK ...
+        view1 = UploadReleaseFile(self.create_request(data))()
+        view2 = UploadReleaseFile(self.create_request(data))()
+        self.assertEqual(set(view2.keys()),
                           set(['pyshop', 'release_file']))
-        self.assertEqual(view['release_file'].filename,
+        self.assertEqual(view2['release_file'].filename,
                           u'local_package1-0.2.tar.gz')
-        self.assertEqual(view['release_file'].release.home_page,
+        self.assertEqual(view2['release_file'].release.home_page,
                           u'http://local_package1')
-        self.assertEqual(view['release_file'].release.author.login,
+        self.assertEqual(view2['release_file'].release.author.login,
                           u'admin')
+
+        # ... unless disabled by policy.
+        self.config.add_settings({'pyshop.upload.never_overwrite': True})
+        with self.assertRaises(HTTPConflict):
+            UploadReleaseFile(self.create_request(data))()

--- a/pyshop/views/simple.py
+++ b/pyshop/views/simple.py
@@ -116,6 +116,11 @@ class UploadReleaseFile(View):
 
         filepath = os.path.join(dir_, filename)
         while os.path.exists(filepath):
+            if asbool(settings.get('pyshop.upload.never_overwrite', '0')):
+                # policy: don't overwrite files that already exist in the repo
+                raise exc.HTTPConflict(
+                    "Uploading version ({}) would overwrite existing file"
+                    .format(params['version']))
             log.warning('File %s exists but new upload self.request, deleting',
                         filepath)
             os.unlink(filepath)

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ requires = [
 ]
 
 
-test_requires = ['nose']
+test_requires = ['nose', 'pyfakefs']
 if sys.version_info < (2, 7):
     test_requires.append('unittest2')
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,3 +3,6 @@ envlist = py27,py34
 envdir=venv
 [testenv]
 commands = nosetests
+deps =
+    nose
+    git+https://github.com/jmcgeheeiv/pyfakefs

--- a/tox.ini
+++ b/tox.ini
@@ -5,4 +5,3 @@ envdir=venv
 commands = nosetests
 deps =
     nose
-    git+https://github.com/jmcgeheeiv/pyfakefs


### PR DESCRIPTION
Prior to this change, re-uploading a package with the same version
results in the old version being overwritten.

In some environments (e.g. with packages being automatically uploaded
from "green" builds of `master`), this can result in programmer error -
forgetting to change `setup.py` versions - changing the "version of
record" in the local `pyshop`.

This change add a new administrative policy option

    pyshop.upload.never_overwrite

which results in re-uploads raising a HTTP Conflict Error.

This change also introduces `pyfakefs` to test cases, which means that
they no longer rely upon real `/tmp` or have filesystem dependencies
across tests.