### PR TITLE
Fix some problem with sort

### DIFF
--- a/pyshop/models.py
+++ b/pyshop/models.py
@@ -515,7 +515,7 @@ class Package(Base):
         """
         releases = [(parse_version(release.version), release)
                     for release in self.releases]
-        releases.sort(reverse=True)
+        releases.sort(reverse=True, key=lambda x: x[0])
         return [release[1] for release in releases]
 
     @classmethod


### PR DESCRIPTION
Some packages, like requests, has a problem with versions. 
Requests have 0.12.1 and 0.12.01 versions, that become equals when converted to Version object.
This cause comparison for Release model that not has comparison functions.

So, just clarify what exactly should be compared on sort.